### PR TITLE
Bugfix: Update Open AI chat completions model to latest

### DIFF
--- a/webui/webui/state.py
+++ b/webui/webui/state.py
@@ -104,7 +104,7 @@ class State(rx.State):
 
         # Start a new session to answer the question.
         session = openai.ChatCompletion.create(
-            model=os.getenv("OPENAI_MODEL","gpt-3.5"),
+            model=os.getenv("OPENAI_MODEL","gpt-3.5-turbo"),
             messages=[
                 { "role": "user", "content": self.question}
             ],


### PR DESCRIPTION
When running out the box get the below error. 

<img width="1058" alt="image" src="https://github.com/reflex-dev/reflex-chat/assets/31546506/ab9b7c55-a44a-48a8-8bb3-27f7c61b7ea2">

Updating it to the latest (`gpt-3.5-turbo`) fixes it.