### PR TITLE
fix: move theme to RadixThemesPlugin to silence 0.9.0 deprecation

### DIFF
--- a/chat/chat.py
+++ b/chat/chat.py
@@ -20,10 +20,5 @@ def index() -> rx.Component:
 
 
 # Add state and page to the app.
-app = rx.App(
-    theme=rx.theme(
-        appearance="dark",
-        accent_color="purple",
-    ),
-)
+app = rx.App()
 app.add_page(index)

--- a/rxconfig.py
+++ b/rxconfig.py
@@ -2,5 +2,10 @@ import reflex as rx
 
 config = rx.Config(
     app_name="chat",
-    plugins=[rx.plugins.SitemapPlugin()],
+    plugins=[
+        rx.plugins.SitemapPlugin(),
+        rx.plugins.RadixThemesPlugin(
+            theme=rx.theme(appearance="dark", accent_color="purple"),
+        ),
+    ],
 )


### PR DESCRIPTION
## Problem

The `templates` repo `check-export` CI fails because `reflex export` emits:

```
DeprecationWarning: App(theme=...) has been deprecated in version 0.9.0.
configure `rx.plugins.RadixThemesPlugin(theme=...)` in `rxconfig.py` instead.
```

## Fix

- Remove `theme=rx.theme(...)` from `rx.App(...)` in `chat/chat.py`.
- Configure the same theme (`appearance="dark"`, `accent_color="purple"`) via `rx.plugins.RadixThemesPlugin(theme=...)` in `rxconfig.py`.

No visual change — same theme, just the non-deprecated configuration.

## Verification

Reproduced the CI locally against the reflex `main` workspace (reflex 0.9.3.dev):

- `reflex export` → no `DeprecationWarning` in logs (was failing before)
- `frontend.zip` / `backend.zip` build and unzip cleanly
- Compiled `.web` output still contains the `dark` / `purple` theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)